### PR TITLE
Fix for Geo Location Data in Ad

### DIFF
--- a/kijiji_manager/kijijiapi.py
+++ b/kijiji_manager/kijijiapi.py
@@ -383,17 +383,17 @@ class KijijiApi:
         else:
             raise KijijiApiException(self._error_reason(doc))
     
-    def geo_location(postal_code):
-        postalcode = check_postal_code_length(postal_code)
+    def geo_location(self, postal_code):
+        postalcode = self.check_postal_code_length(postal_code)
         try:
             nomi = pgeocode.Nominatim('ca')
-            location = nomi.query_postal_code(postal_code)
+            location = nomi.query_postal_code(postalcode)
         except:
             raise KijijiApiException('Error acquiring geo location data')
         else:
             return location
         
-    def check_postal_code_length(postal_code):
+    def check_postal_code_length(self, postal_code):
         if len(postal_code) == 6:
             section1 = postal_code[:3]
             section2 = postal_code[3:6]

--- a/kijiji_manager/kijijiapi.py
+++ b/kijiji_manager/kijijiapi.py
@@ -1,6 +1,7 @@
 from xml.parsers.expat import ExpatError, errors
 
 import httpx
+import pgeocode
 import xmltodict
 
 
@@ -381,7 +382,25 @@ class KijijiApi:
             return doc
         else:
             raise KijijiApiException(self._error_reason(doc))
-
+    
+    def geo_location(postal_code):
+        postalcode = checkPostalCodeLength(postal_code)
+        try:
+            nomi = pgeocode.Nominatim('ca')
+            location = nomi.query_postal_code(postal_code)
+        except:
+            raise KijijiApiException('Error acquiring geo location data')
+        else:
+            return location
+        
+    def checkPostalCodeLength(postal_code):
+        if len(postal_code) == 6:
+            section1 = postal_code[:3]
+            section2 = postal_code[3:6]
+            return section1 + ' ' + section2
+        else:
+            return postal_code
+    
     @staticmethod
     def _headers_with_auth(user_id, token):
         return {'X-ECG-Authorization-User': f'id="{user_id}", token="{token}"'}

--- a/kijiji_manager/kijijiapi.py
+++ b/kijiji_manager/kijijiapi.py
@@ -384,7 +384,7 @@ class KijijiApi:
             raise KijijiApiException(self._error_reason(doc))
     
     def geo_location(postal_code):
-        postalcode = checkPostalCodeLength(postal_code)
+        postalcode = check_postal_code_length(postal_code)
         try:
             nomi = pgeocode.Nominatim('ca')
             location = nomi.query_postal_code(postal_code)
@@ -393,7 +393,7 @@ class KijijiApi:
         else:
             return location
         
-    def checkPostalCodeLength(postal_code):
+    def check_postal_code_length(postal_code):
         if len(postal_code) == 6:
             section1 = postal_code[:3]
             section2 = postal_code[3:6]

--- a/kijiji_manager/kijijiapi.py
+++ b/kijiji_manager/kijijiapi.py
@@ -392,14 +392,6 @@ class KijijiApi:
             raise KijijiApiException('Error acquiring geo location data')
         else:
             return location
-        
-    def check_postal_code_length(self, postal_code):
-        if len(postal_code) == 6:
-            section1 = postal_code[:3]
-            section2 = postal_code[3:6]
-            return section1 + ' ' + section2
-        else:
-            return postal_code
     
     @staticmethod
     def _headers_with_auth(user_id, token):

--- a/kijiji_manager/kijijiapi.py
+++ b/kijiji_manager/kijijiapi.py
@@ -384,7 +384,8 @@ class KijijiApi:
             raise KijijiApiException(self._error_reason(doc))
     
     def geo_location(self, postal_code):
-        postalcode = self.check_postal_code_length(postal_code)
+        # pgeocode.Nominatim.query_postal_code only uses the first three characters to do the lookup for Canadian postal codes
+        postalcode = postal_code[:3]
         try:
             nomi = pgeocode.Nominatim('ca')
             location = nomi.query_postal_code(postalcode)

--- a/kijiji_manager/views/ad.py
+++ b/kijiji_manager/views/ad.py
@@ -217,7 +217,10 @@ def post():
         # Get most significant location ID from given set of locations in previous step form
         # Default to 'Canada' => '0' if none given
         location_choice = (lambda x1, x2, x3: x3 if x3 else x2 if x2 else x1 if x1 else '0')(form.loc1.data, form.loc2.data, form.loc3.data)
-
+        
+        # Generate Geo Location Data
+        location = geo_location(form.postalcode.data)
+        
         # Begin assembling entire payload
         # All of the keys in the following dict are always present in every ad post payload,
         # however some may be left empty if not used
@@ -246,8 +249,8 @@ def post():
                 'ad:phone': form.phone.data,
                 'ad:ad-address': {
                     'types:radius': 400,
-                    'types:latitude': None,
-                    'types:longitude': None,
+                    'types:latitude': location.latitude,
+                    'types:longitude': location.longitude,
                     'types:full-address': None,
                     'types:zip-code': form.postalcode.data,
                 },

--- a/kijiji_manager/views/ad.py
+++ b/kijiji_manager/views/ad.py
@@ -219,7 +219,7 @@ def post():
         location_choice = (lambda x1, x2, x3: x3 if x3 else x2 if x2 else x1 if x1 else '0')(form.loc1.data, form.loc2.data, form.loc3.data)
         
         # Generate Geo Location Data
-        location = geo_location(form.postalcode.data)
+        location = kijiji_api.geo_location(form.postalcode.data)
         
         # Begin assembling entire payload
         # All of the keys in the following dict are always present in every ad post payload,

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ is-safe-url==1.0
 itsdangerous==2.0.1
 Jinja2==3.0.1
 MarkupSafe==2.0.1
+pgeocode==0.3.0
 phonenumbers==8.12.31
 rfc3986==1.5.0
 sniffio==1.2.0


### PR DESCRIPTION
Fixes an issue where ads are given 0,0 for geo location data, resulting in ads appearing in the South Atlantic.
Requires an additional module installation: `pgeocode`