### PR TITLE
fix

### DIFF
--- a/kijiji_manager/views/ad.py
+++ b/kijiji_manager/views/ad.py
@@ -50,7 +50,7 @@ def post_manual():
                 os.makedirs(user_dir)
             ad_file = os.path.join(user_dir, f'{ad_id}.xml')
             with open(ad_file, 'w', encoding='utf-8') as f:
-                if isInstance(xml_payload, str) != True:
+                if isinstance(xml_payload, bytes):
                     xml_payload = xml_payload.decode('utf-8')
                 f.write(xml_payload)
             flash(f'Ad {ad_id} payload saved to {ad_file}')

--- a/kijiji_manager/views/ad.py
+++ b/kijiji_manager/views/ad.py
@@ -50,6 +50,8 @@ def post_manual():
                 os.makedirs(user_dir)
             ad_file = os.path.join(user_dir, f'{ad_id}.xml')
             with open(ad_file, 'w', encoding='utf-8') as f:
+                if isInstance(xml_payload, str) != True:
+                    xml_payload = xml_payload.decode('utf-8')
                 f.write(xml_payload)
             flash(f'Ad {ad_id} payload saved to {ad_file}')
 


### PR DESCRIPTION
```
[2022-06-20 19:28:44,842] ERROR in app: Exception on /post_manual [POST]
Traceback (most recent call last):
File "/kijiji-manager/venv/lib/python3.10/site-packages/flask/app.py", line 2073, in wsgi_app
response = self.full_dispatch_request()
File "/kijiji-manager/venv/lib/python3.10/site-packages/flask/app.py", line 1518, in full_dispatch_request
rv = self.handle_user_exception(e)
File "/kijiji-manager/venv/lib/python3.10/site-packages/flask/app.py", line 1516, in full_dispatch_request
rv = self.dispatch_request()
File "/kijiji-manager/venv/lib/python3.10/site-packages/flask/app.py", line 1502, in dispatch_request
return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
File "kijiji-manager/venv/lib/python3.10/site-packages/flask_login/utils.py", line 303, in decorated_view
return current_app.ensure_sync(func)(*args, **kwargs)
File "kijiji-manager/kijiji_manager/views/ad.py", line 53, in post_manual
f.write(xml_payload)
TypeError: write() argument must be str, not bytes
```

Was breaking during manual post -> 
       check data type and encoding.
       change variable if detected. 